### PR TITLE
V.0.3.5.6 upgrade clap 4.5

### DIFF
--- a/fluent_cli/Cargo.toml
+++ b/fluent_cli/Cargo.toml
@@ -9,8 +9,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json", "blocking", "multipart", "stream"] }
 tokio = { version = "1", features = ["full"] }
-clap = { version = "3.0", features = ["derive"] }
-clap_complete_fig = "3.1"
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5.2"
+clap_complete_fig = "4.5.0"
 tokio-console = "0.1" # For debugging async tasks
 config = "0.12"
 log = "0.4"

--- a/fluent_cli/config.json
+++ b/fluent_cli/config.json
@@ -116,6 +116,7 @@
     },
     "timeout_ms": 500000
   },
+
   {
     "name": "LangFlowExample",
     "engine": "langflow",
@@ -134,23 +135,23 @@
     },
 
     "tweaks": {
-      "Prompt-dqVZJ": {
-        "template": "you are a helpful assistant"
+      "Prompt-PbKIE": {
+        "template": "you are a bunny rabbit",
+        "user_input": "give me some markdown syntax examples"
       },
-      "OpenAIModel-CIM9V": {
+      "OpenAIModel-Wnn5j": {
         "openai_api_key": "AMBER_FLUENT_OPENAI_API_KEY_01",
         "model_name": "gpt-4-turbo-preview"
       },
-      "ChatOutput-wTcXM": {
+      "ChatOutput-6PVYx": {
         "session_id": "AMBER_FLUENT_SESSION_ID_01"
       },
-      "ChatInput-zRWPE": {
+      "ChatInput-6JYUL": {
         "session_id": "AMBER_FLUENT_SESSION_ID_01"
       }
     },
     "timeout_ms": 50000
   },
-
   {
     "name": "LangFlowBlogWriterExample",
     "engine": "langflow",

--- a/fluent_cli/fluent.ts
+++ b/fluent_cli/fluent.ts
@@ -1,0 +1,143 @@
+const completion: Fig.Spec = {
+  name: "fluent",
+  description: "Interacts with FlowiseAI, Langflow, and Webhook workflows",
+  args: [
+    {
+      name: "flowname",
+      isCommand:true,
+      generators: [{
+        script: ["jq",  "-r", ".[].name", "/Users/n/RustroverProjects/fluent_cli/fluent_cli/config.json"],
+      postProcess: (out: string) => {
+        return out.split('\n').filter(Boolean).map((name) => {  
+          return { name: name, description: "flow name"}
+        })
+      }
+      }]
+    },
+    {
+      name: "request",
+      description: "Specify the request",
+      isOptional: false,
+      isCommand: false,
+    },
+  ],
+  options: [
+    {
+      name: "-c",
+      description: "Optional context to include with the request",
+      isRepeatable: false,
+      args: {
+        name: "context",
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-i", "--system-prompt-override-inline"],
+      description: "Overrides the system message with an inline string",
+      isRepeatable: false,
+      args: {
+        name: "system-prompt-override-inline",
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-f", "--system-prompt-override-file"],
+      description: "Overrides the system message from a specified file",
+      isRepeatable: false,
+      args: {
+        name: "system-prompt-override-file",
+        template: "filepaths",
+        isVariadic: true,
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-a", "--additional-context-file"],
+      description: "Specifies a file from which additional request context is loaded",
+      isRepeatable: false,
+      args: {
+        name: "additional-context-file",
+        template: "filepaths",
+        isVariadic: true,
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-u", "--upload-image-path"],
+      description: "Sets the input file to use",
+      isRepeatable: false,
+      args: {
+        name: "upload-image-path",
+        template: "filepaths",
+        isVariadic: true,
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-d", "--download-media"],
+      description: "Downloads all media files listed in the output to a specified directory",
+      isRepeatable: false,
+      args: {
+        name: "download-media",
+        template: "folders",
+        isVariadic: true,
+        isOptional: true,
+      },
+    },
+    {
+      name: "--upsert-no-upload",
+      description: "Sends a JSON payload to the specified endpoint without uploading files",
+      isRepeatable: false,
+      args: {
+        name: "upsert-no-upload",
+        isOptional: true,
+      },
+    },
+    {
+      name: "--upsert-with-upload",
+      description: "Uploads a file to the specified endpoint",
+      isRepeatable: false,
+      args: {
+        name: "upsert-with-upload",
+        template: "filepaths",
+        isVariadic: true,
+        isOptional: true,
+      },
+    },
+    {
+      name: ["--generate-autocomplete"],
+      description: "Generates a bash autocomplete script",
+
+    },
+    {
+      name: "--generate-fig-autocomplete",
+      description: "Generates a fig autocomplete script",
+    },
+    {
+      name: ["-p", "--parse-code-output"],
+      description: "Extracts and displays only the code blocks from the response",
+    },
+    {
+      name: ["-z", "--full-output"],
+      description: "Outputs all response data in JSON format",
+    },
+    {
+      name: ["-m", "--markdown-output"],
+      description: "Outputs the response to the terminal in stylized markdown. Do not use for pipelines",
+    },
+    {
+      name: "--webhook",
+      description: "Sends the command payload to the webhook URL specified in config.json",
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Print help",
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Print version",
+    },
+  ],
+};
+
+export default completion;

--- a/fluent_cli/functional_tests/functional_test_02.sh
+++ b/fluent_cli/functional_tests/functional_test_02.sh
@@ -11,7 +11,7 @@ CONTEXT_FILE="$TEST_DATA_PATH/functional_test_context.txt"
 
 # Validation CLI and Flowname
 VALIDATION_CLI="fluent"
-VALIDATION_FLOWNAME="GroqLLama370b8192AgentRepoCloud"
+VALIDATION_FLOWNAME="HaikuChain"
 
 # Flow names array
 declare -a FLOWNAMES=("HaikuChain" "SonnetXMLAgentRepoCloud" "OpusXMLAgentRepoCloud" "GPT4ImageUploadRepoCloud" "GroqGemma7bAgentRepoCloud" "GroqLLama370b8192AgentRepoCloud" "GroqMixtral8x7bAgentRepoCloud" "PerplexitySonarSmallOnlineChainRepoCloud")
@@ -76,52 +76,52 @@ for FLOWNAME in "${FLOWNAMES[@]}"; do
     echo ""
 
     run_test "$FLOWNAME" "Base Command Test" \
-        "$CLI_PATH $FLOWNAME 'This is a test, reply this is a test'" \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request is about this is a test'"
+        "$CLI_PATH $FLOWNAME 'This is a test'" \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL if this is a test'"
 
     run_test "$FLOWNAME" "Stdin Context Test" \
-        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, Summarize this'" \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request references the word northstar or North Star'"
+        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, what is the context'" \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL the request is this is a test and about the northstar'"
 
     run_test "$FLOWNAME" "Additional Context File Test" \
-        "$CLI_PATH $FLOWNAME 'This is a test, Summarize  what I provide ' --additional-context-file \"$OUTLINE_FILE\"" \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request references the word TheLardCatFellFlatOnTheMat'"
+        "$CLI_PATH $FLOWNAME 'This is a test, what is the outline  the outline ' --additional-context-file \"$OUTLINE_FILE\"" \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL if it includes the word TheLardCatFellFlatOnTheMat and  the word northstar or North Star'"
 
     run_test "$FLOWNAME" "Combined Stdin and Additional Context Test" \
-        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, Summarize what I provide: ' --additional-context-file \"$OUTLINE_FILE\"" \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the response contains TheLardCatFellFlatOnTheMat and references  the word northstar or North Star'"
+        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, what is the context and the outline ' --additional-context-file \"$OUTLINE_FILE\"" \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL if it includes the word northstar and the word TheLardCatFellFlatOnTheMat'"
 
     run_test "$FLOWNAME" "Base Command Test and --system-prompt-override-inline" \
         "$CLI_PATH $FLOWNAME 'This is a test, respond that this is a test' --system-prompt-override-inline 'You can only reply in German'" \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if request is in German'"
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if request is partly in German'"
 
     run_test "$FLOWNAME" "Stdin Context Test and --system-prompt-override-inline" \
-        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, Summarize what what I provide in the request:' --system-prompt-override-inline 'You can only reply in German' " \
+        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, what is the context:' --system-prompt-override-inline 'You can only reply in German' " \
         "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request is partly in German'"
 
     run_test "$FLOWNAME" "Additional Context File Test and --system-prompt-override-inline" \
-        "$CLI_PATH $FLOWNAME 'This is a test, Summarize what I provided in the request' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-inline 'You can only reply in German' " \
+        "$CLI_PATH $FLOWNAME 'This is a test,what is the outline' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-inline 'You can only reply in German' " \
         "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request  is partly in German'"
 
     run_test "$FLOWNAME" "Combined Stdin and Additional Context Test and --system-prompt-override-inline" \
-        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, Summarize what what I provide in the request' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-inline 'You can only reply in German'" \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request  is partly in German'"
+        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, what is the context and what is the outline' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-inline 'You can only reply in German'" \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request is partly in German'"
 
     run_test "$FLOWNAME" "Base Command Test and --system-prompt-override-file" \
         "$CLI_PATH $FLOWNAME 'This is a test, Summarize that this is a test' --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request has spanish words'"
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request partly in spanish'"
 
     run_test "$FLOWNAME" "Stdin Context Test and --system-prompt-override-file" \
-        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, Summarize what with  what I provide in the request ' --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request has Spanish words'"
+        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, what is the context' --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request is partly in spanish'"
 
     run_test "$FLOWNAME" "Additional Context File Test and --system-prompt-override-file" \
-        "$CLI_PATH $FLOWNAME 'This is a test, Summarize what I provide in the request' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request has Spanish words'"
+        "$CLI_PATH $FLOWNAME 'This is a test, what is the outline' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request is partly in spanish'"
 
     run_test "$FLOWNAME" "Combined Stdin and Additional Context Test and --system-prompt-override-file" \
-        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, Summarize what I provide in the request:' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
-        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request has Spanish words'"
+        "cat \"$CONTEXT_FILE\" | $CLI_PATH $FLOWNAME 'This is a test, what is the outline and what is the context' --additional-context-file \"$OUTLINE_FILE\" --system-prompt-override-file \"$SYSTEM_PROMPT_FILE\" " \
+        "$VALIDATION_CLI $VALIDATION_FLOWNAME 'Answer PASS or FAIL only if the request is partly in spanish'"
 
 done
 

--- a/fluent_cli/src/client.rs
+++ b/fluent_cli/src/client.rs
@@ -469,7 +469,7 @@ pub async fn prepare_payload(flow: &FlowConfig, question: &str, file_path: Optio
     );
 
     let mut body = match flow.engine.as_str() {
-        "flowise" | "webhook" => {
+        "flowise" => {
             serde_json::json!({
                 "question": full_question,
                 "overrideConfig": override_config,
@@ -481,6 +481,14 @@ pub async fn prepare_payload(flow: &FlowConfig, question: &str, file_path: Optio
             serde_json::json!({
                 "question": full_question,
                 "tweaks": tweaks_config,
+            })
+        },
+        "webhook" => {
+            serde_json::json!({
+                "question": full_question,
+                "context": actual_final_context,
+                "file_contents": _file_contents,
+                "overrideConfig": override_config,
             })
         },
         _ => {

--- a/fluent_cli/src/config.rs
+++ b/fluent_cli/src/config.rs
@@ -177,18 +177,5 @@ pub fn load_config() -> Result<Vec<FlowConfig>, Box<dyn Error>> {
 }
 
 
-pub fn generate_bash_autocomplete_script() -> String {
-
-    return format!(r#"
-# Assuming FLUENT_CLI_CONFIG_PATH points to a JSON file containing configuration
-autocomplete_flows() {{
-    local current_word="${{COMP_WORDS[COMP_CWORD]}}"
-    local flow_names=$(jq -r '.[].name' "$FLUENT_CLI_CONFIG_PATH")
-    COMPREPLY=($(compgen -W "${{flow_names}}" -- "$current_word"))
-}}
-complete -F autocomplete_flows fluent_cli
-"#)
-
-}
 
 

--- a/fluent_cli/src/fig_config.rs
+++ b/fluent_cli/src/fig_config.rs
@@ -1,0 +1,492 @@
+#![allow(clippy::write_with_newline)]
+
+use std::fmt::Write;
+
+// Internal
+use clap::*;
+use clap_complete::*;
+use log::debug;
+
+/// Generate fig completion file
+pub struct Fig;
+
+impl Generator for Fig {
+    fn file_name(&self, name: &str) -> String {
+        format!("{name}.ts")
+    }
+
+    fn generate(&self, cmd: &Command, buf: &mut dyn std::io::Write) {
+        print!("Command {}", cmd);
+        debug!("Command {}", cmd);
+        let command_name = cmd.get_bin_name().unwrap();
+        let mut buffer = String::new();
+
+        write!(
+            &mut buffer,
+            "const completion: Fig.Spec = {{\n  name: \"{}\",\n",
+            escape_string(command_name)
+        )
+            .unwrap();
+
+        write!(
+            &mut buffer,
+            "  description: \"{}\",\n",
+            escape_string(&cmd.get_about().unwrap_or_default().to_string())
+        )
+            .unwrap();
+
+        gen_fig_inner(&[], 2, cmd, &mut buffer);
+
+        write!(&mut buffer, "}};\n\nexport default completion;\n").unwrap();
+
+        buf.write_all(buffer.as_bytes())
+            .expect("Failed to write to generated file");
+    }
+}
+
+// Escape string inside double quotes and convert whitespace
+fn escape_string(string: &str) -> String {
+    string
+        .replace('\\', "\\\\")
+        .replace('\"', "\\\"")
+        .replace('\t', "    ")
+        .replace('\n', " ")
+        .replace('\r', "")
+}
+
+fn gen_fig_inner(parent_commands: &[&str], indent: usize, cmd: &Command, buffer: &mut String) {
+    if cmd.has_subcommands() {
+        write!(buffer, "{:indent$}subcommands: [\n", "").unwrap();
+        // generate subcommands
+        for subcommand in cmd.get_subcommands() {
+            let mut aliases: Vec<&str> = subcommand.get_all_aliases().collect();
+            if !aliases.is_empty() {
+                aliases.insert(0, subcommand.get_name());
+
+                write!(
+                    buffer,
+                    "{:indent$}{{\n{:indent$}  name: [",
+                    "",
+                    "",
+                    indent = indent + 2
+                )
+                    .unwrap();
+
+                buffer.push_str(
+                    &aliases
+                        .iter()
+                        .map(|name| format!("\"{}\"", escape_string(name)))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+
+                write!(buffer, "],\n").unwrap();
+            } else {
+                write!(
+                    buffer,
+                    "{:indent$}{{\n{:indent$}  name: \"{}\",\n",
+                    "",
+                    "",
+                    escape_string(subcommand.get_name()),
+                    indent = indent + 2
+                )
+                    .unwrap();
+            }
+
+            if let Some(data) = subcommand.get_about() {
+                write!(
+                    buffer,
+                    "{:indent$}description: \"{}\",\n",
+                    "",
+                    escape_string(&data.to_string()),
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            if subcommand.is_hide_set() {
+                write!(buffer, "{:indent$}hidden: true,\n", "", indent = indent + 4).unwrap();
+            }
+
+            let mut parent_commands: Vec<_> = parent_commands.into();
+            parent_commands.push(subcommand.get_name());
+            gen_fig_inner(&parent_commands, indent + 4, subcommand, buffer);
+
+            write!(buffer, "{:indent$}}},\n", "", indent = indent + 2).unwrap();
+        }
+        write!(buffer, "{:indent$}],\n", "").unwrap();
+    }
+
+    buffer.push_str(&gen_options(cmd, indent));
+
+    let args = cmd.get_positionals().collect::<Vec<_>>();
+
+    match args.len() {
+        0 => {}
+        1 => {
+            write!(buffer, "{:indent$}args: ", "").unwrap();
+
+            buffer.push_str(&gen_args(args[0], indent));
+        }
+        _ => {
+            write!(buffer, "{:indent$}args: [\n", "").unwrap();
+            for arg in args {
+                write!(buffer, "{:indent$}", "", indent = indent + 2).unwrap();
+                buffer.push_str(&gen_args(arg, indent + 2));
+            }
+            write!(buffer, "{:indent$}]\n", "").unwrap();
+        }
+    };
+}
+
+fn gen_options(cmd: &Command, indent: usize) -> String {
+    let mut buffer = String::new();
+
+    let flags = generator::utils::flags(cmd);
+
+    if cmd.get_opts().next().is_some() || !flags.is_empty() {
+        write!(&mut buffer, "{:indent$}options: [\n", "").unwrap();
+
+        for option in cmd.get_opts() {
+            write!(&mut buffer, "{:indent$}{{\n", "", indent = indent + 2).unwrap();
+
+            let mut names = vec![];
+
+            if let Some(shorts) = option.get_short_and_visible_aliases() {
+                names.extend(
+                    shorts
+                        .iter()
+                        .map(|short| format!("-{}", escape_string(&short.to_string()))),
+                );
+            }
+
+            if let Some(longs) = option.get_long_and_visible_aliases() {
+                names.extend(
+                    longs
+                        .iter()
+                        .map(|long| format!("--{}", escape_string(long))),
+                );
+            }
+
+            if names.len() > 1 {
+                write!(&mut buffer, "{:indent$}name: [", "", indent = indent + 4).unwrap();
+
+                buffer.push_str(
+                    &names
+                        .iter()
+                        .map(|name| format!("\"{}\"", escape_string(name)))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+
+                buffer.push_str("],\n");
+            } else {
+                write!(
+                    &mut buffer,
+                    "{:indent$}name: \"{}\",\n",
+                    "",
+                    escape_string(&names[0]),
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            if let Some(data) = option.get_help() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}description: \"{}\",\n",
+                    "",
+                    escape_string(&data.to_string()),
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            if option.is_hide_set() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}hidden: true,\n",
+                    "",
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            let conflicts = arg_conflicts(cmd, option);
+
+            if !conflicts.is_empty() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}exclusiveOn: [\n",
+                    "",
+                    indent = indent + 4
+                )
+                    .unwrap();
+
+                for conflict in conflicts {
+                    write!(
+                        &mut buffer,
+                        "{:indent$}\"{}\",\n",
+                        "",
+                        escape_string(&conflict),
+                        indent = indent + 6
+                    )
+                        .unwrap();
+                }
+
+                write!(&mut buffer, "{:indent$}],\n", "", indent = indent + 4).unwrap();
+            }
+
+            if let ArgAction::Set | ArgAction::Append | ArgAction::Count = option.get_action() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}isRepeatable: true,\n",
+                    "",
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            if option.is_require_equals_set() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}requiresEquals: true,\n",
+                    "",
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            write!(&mut buffer, "{:indent$}args: ", "", indent = indent + 4).unwrap();
+
+            buffer.push_str(&gen_args(option, indent + 4));
+
+            write!(&mut buffer, "{:indent$}}},\n", "", indent = indent + 2).unwrap();
+        }
+
+        for flag in generator::utils::flags(cmd) {
+            write!(&mut buffer, "{:indent$}{{\n", "", indent = indent + 2).unwrap();
+
+            let mut flags = vec![];
+
+            if let Some(shorts) = flag.get_short_and_visible_aliases() {
+                flags.extend(shorts.iter().map(|s| format!("-{s}")));
+            }
+
+            if let Some(longs) = flag.get_long_and_visible_aliases() {
+                flags.extend(longs.iter().map(|s| format!("--{s}")));
+            }
+
+            if flags.len() > 1 {
+                write!(&mut buffer, "{:indent$}name: [", "", indent = indent + 4).unwrap();
+
+                buffer.push_str(
+                    &flags
+                        .iter()
+                        .map(|name| format!("\"{}\"", escape_string(name)))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+
+                buffer.push_str("],\n");
+            } else {
+                write!(
+                    &mut buffer,
+                    "{:indent$}name: \"{}\",\n",
+                    "",
+                    escape_string(&flags[0]),
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            if let Some(data) = flag.get_help() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}description: \"{}\",\n",
+                    "",
+                    escape_string(&data.to_string()).as_str(),
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            let conflicts = arg_conflicts(cmd, &flag);
+
+            if !conflicts.is_empty() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}exclusiveOn: [\n",
+                    "",
+                    indent = indent + 4
+                )
+                    .unwrap();
+
+                for conflict in conflicts {
+                    write!(
+                        &mut buffer,
+                        "{:indent$}\"{}\",\n",
+                        "",
+                        escape_string(&conflict),
+                        indent = indent + 6
+                    )
+                        .unwrap();
+                }
+
+                write!(&mut buffer, "{:indent$}],\n", "", indent = indent + 4).unwrap();
+            }
+
+            if let ArgAction::Set | ArgAction::Append | ArgAction::Count = flag.get_action() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}isRepeatable: true,\n",
+                    "",
+                    indent = indent + 4
+                )
+                    .unwrap();
+            }
+
+            write!(&mut buffer, "{:indent$}}},\n", "", indent = indent + 2).unwrap();
+        }
+
+        write!(&mut buffer, "{:indent$}],\n", "").unwrap();
+    }
+
+    buffer
+}
+
+fn gen_args(arg: &Arg, indent: usize) -> String {
+    if !arg.get_num_args().expect("built").takes_values() {
+        return "".to_string();
+    }
+
+    let mut buffer = String::new();
+
+    write!(
+        &mut buffer,
+        "{{\n{:indent$}  name: \"{}\",\n",
+        "",
+        escape_string(arg.get_id().as_str()),
+        indent = indent
+    )
+        .unwrap();
+
+    let num_args = arg.get_num_args().expect("built");
+    if num_args != builder::ValueRange::EMPTY && num_args != builder::ValueRange::SINGLE {
+        write!(
+            &mut buffer,
+            "{:indent$}isVariadic: true,\n",
+            "",
+            indent = indent + 2
+        )
+            .unwrap();
+    }
+
+    if !arg.is_required_set() {
+        write!(
+            &mut buffer,
+            "{:indent$}isOptional: true,\n",
+            "",
+            indent = indent + 2
+        )
+            .unwrap();
+    }
+
+    if let Some(data) = generator::utils::possible_values(arg) {
+        write!(
+            &mut buffer,
+            "{:indent$}suggestions: [\n",
+            "",
+            indent = indent + 2
+        )
+            .unwrap();
+
+        for value in data {
+            if let Some(help) = value.get_help() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}{{\n{:indent$}  name: \"{}\",\n",
+                    "",
+                    "",
+                    escape_string(value.get_name()),
+                    indent = indent + 4,
+                )
+                    .unwrap();
+
+                write!(
+                    &mut buffer,
+                    "{:indent$}description: \"{}\",\n",
+                    "",
+                    escape_string(&help.to_string()),
+                    indent = indent + 6
+                )
+                    .unwrap();
+
+                write!(&mut buffer, "{:indent$}}},\n", "", indent = indent + 4).unwrap();
+            } else {
+                write!(
+                    &mut buffer,
+                    "{:indent$}\"{}\",\n",
+                    "",
+                    escape_string(value.get_name()),
+                    indent = indent + 4,
+                )
+                    .unwrap();
+            }
+        }
+
+        write!(&mut buffer, "{:indent$}],\n", "", indent = indent + 2).unwrap();
+    } else {
+        match arg.get_value_hint() {
+            ValueHint::AnyPath | ValueHint::FilePath | ValueHint::ExecutablePath => {
+                write!(
+                    &mut buffer,
+                    "{:indent$}template: \"filepaths\",\n",
+                    "",
+                    indent = indent + 2
+                )
+                    .unwrap();
+            }
+            ValueHint::DirPath => {
+                write!(
+                    &mut buffer,
+                    "{:indent$}template: \"folders\",\n",
+                    "",
+                    indent = indent + 2
+                )
+                    .unwrap();
+            }
+            ValueHint::CommandString | ValueHint::CommandName | ValueHint::CommandWithArguments => {
+                write!(
+                    &mut buffer,
+                    "{:indent$}isCommand: true,\n",
+                    "",
+                    indent = indent + 2
+                )
+                    .unwrap();
+            }
+            // Disable completion for others
+            _ => (),
+        };
+    };
+
+    write!(&mut buffer, "{:indent$}}},\n", "").unwrap();
+
+    buffer
+}
+
+fn arg_conflicts(cmd: &Command, arg: &Arg) -> Vec<String> {
+    let mut res = vec![];
+
+    for conflict in cmd.get_arg_conflicts_with(arg) {
+        if let Some(s) = conflict.get_short() {
+            res.push(format!("-{}", escape_string(&s.to_string())));
+        }
+
+        if let Some(l) = conflict.get_long() {
+            res.push(format!("--{}", escape_string(l)));
+        }
+    }
+
+    res
+}

--- a/fluent_cli/src/lib.rs
+++ b/fluent_cli/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
 pub mod client;
+


### PR DESCRIPTION
 The following changes were made:
    
    - Added a new fluent.ts file containing the Fig autocomplete script.
    - Updated Cargo.toml to use the clap_complete_fig crate for generating Fig autocomplete.
    - Modified the main.rs file to support Fig autocomplete script generation and removed the old bash autocomplete script.
    - Updated the client.rs file to ensure webhooks receive all relevant data.
    - Created a new fig_config.rs file containing the logic for generating the Fig autocomplete script.
    
    This improvement allows users to benefit from Fig's advanced autocomplete capabilities for the fluent CLI.

┆Issue is synchronized with this [Trello card](https://trello.com/c/EzagQclH) by [Unito](https://www.unito.io)
