### PR TITLE
V.0.3.5.7 rewrite the overrides and add dynamic replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Cargo.lock
 .idea/workspace.xml
 fluent_cli/.DS_Store
 fluent_cli/available_fields_cache.json
+fluent_cli/functional_tests/available_fields_cache.json

--- a/fluent_cli/config.json
+++ b/fluent_cli/config.json
@@ -172,21 +172,60 @@
       "Prompt-sU980": {},
       "URL-m0Ust": {
         "urls": [
-          "https://github.com/njfio/fluent_cli"
+          ""
         ]
       },
+      "ChatOutput-804eN": {
+        "system_message": "You are a helpful assistant"
+      },
       "OpenAIModel-xHBgn": {
-        "openai_api_key": "AMBER_FLUENT_OPENAI_API_KEY_01",
-        "model_name": "gpt-4-turbo-preview"
+        "model_kwargs": {}
       },
       "URL-cJhLd": {
         "urls": [
-          "https://www.fluentcli.com"
+          ""
         ]
       },
       "TextInput-eohW7": {
-        "input_value": "Use the references above for style to write a new blog/tutorial about FluentCLI. Suggest non-covered topics."
+        "record_template": ""
       }
+    },
+    "timeout_ms": 50000
+  },
+  {
+    "name": "LangFlowChainOfThoughtExample",
+    "engine": "langflow",
+    "protocol": "https",
+    "hostname": "njfio-langflow-preview.hf.space",
+    "port": 443,
+    "request_path": "/api/v1/run/",
+    "chat_id": "2f224ad7-3579-4e4b-8964-18678fd2ee01",
+    "bearer_token": "AMBER_REPO_CLOUD_FLUENT_DEMO_KEY",
+    "input_value_key": "input_value",
+    "input_value": "message",
+    "sessionId": "",
+    "output_type": "chat",
+    "input_type": "chat",
+    "overrideConfig": {
+
+    },
+    "tweaks": {
+      "Prompt-DoqBg": {
+      },
+      "ChatOutput-g2gga": {},
+      "OpenAIModel-WvjnV": {
+        "model_kwargs": {},
+        "openai_api_key": "AMBER_FLUENT_OPENAI_API_KEY_01"
+      },
+      "TextInput-0pH93": {
+        "input_value": "message"
+      },
+      "Prompt-xiPZp": {
+      },
+      "OpenAIModel-dCDLX": {
+        "openai_api_key": "AMBER_FLUENT_OPENAI_API_KEY_01"
+      },
+      "ChatOutput-mBx2g": {}
     },
     "timeout_ms": 50000
   },
@@ -872,14 +911,12 @@
     "sessionId": "",
     "bearer_token": "AMBER_MAKE_LEONARDO_IMAGE_POST",
     "overrideConfig": {
-      "modelID": "AMBER_LEONARDO_AI_KINO_XL_MODEL_ID",
-      "negative_prompt": "words, letters, symbols, hands, deformities, low-quality,",
-      "alchemy": true,
-      "photoReal": true,
-      "photoRealVersion":"v2",
-      "presetStyle": "",
-      "makeAuthentication": "AMBER_MAKE_LEONARDO_IMAGE_POST",
-      "seed": ""
+      "size": "1024x1792",
+      "quality":"HD",
+      "style": "Vivid",
+      "responseFormat": "url",
+      "makeAuthentication": "AMBER_MAKE_LEONARDO_IMAGE_POST"
+
     },
     "tweaks": {
 

--- a/fluent_cli/config.json
+++ b/fluent_cli/config.json
@@ -11,7 +11,7 @@
     "sessionId": "AMBER_FLUENT_SESSION_ID_01",
     "bearer_token": "AMBER_REPO_CLOUD_FLUENT_DEMO_KEY",
     "overrideConfig": {
-
+      "modelName": "gemini-1.5-pro-latest"
     },
     "tweaks": {
 

--- a/fluent_cli/fluent.ts
+++ b/fluent_cli/fluent.ts
@@ -1,141 +1,205 @@
 const completion: Fig.Spec = {
   name: "fluent",
   description: "Interacts with FlowiseAI, Langflow, and Webhook workflows",
+  cache: false,
+  priority: 100000,
+  parserDirectives: {
+    optionsMustPrecedeArguments: false,
+    flagsArePosixNoncompliant: true,
+  },
   args: [
     {
-      name: "flowname",
-      isCommand:true,
-      generators: [{
-        script: ["jq",  "-r", ".[].name", "/Users/n/RustroverProjects/fluent_cli/fluent_cli/config.json"],
-      postProcess: (out: string) => {
-        return out.split('\n').filter(Boolean).map((name) => {  
-          return { name: name, description: "flow name"}
-        })
-      }
-      }]
+      name: "flow",
+      isScript: false,
+      isOptional: false,
+      generators: {
+        script: ["jq", "-r", '.[].name', "/Users/n/RustroverProjects/fluent_cli/fluent_cli/config.json"],
+        postProcess: (out: string) => {
+          return out.split('\n').filter(Boolean).map((name) => {
+            return {
+              name: name,
+              description: "Flow name",
+              icon: "🫠",
+            };
+          });
+        },
+      },
     },
     {
       name: "request",
+      optionsCanBreakVariadicArg: true,
       description: "Specify the request",
-      isOptional: false,
       isCommand: false,
+      isOptional: false,
+      isVariadic: true,
+      default: "{cursor}",
     },
   ],
   options: [
     {
-      name: "-c",
-      description: "Optional context to include with the request",
-      isRepeatable: false,
-      args: {
-        name: "context",
-        isOptional: true,
-      },
-    },
-    {
       name: ["-i", "--system-prompt-override-inline"],
       description: "Overrides the system message with an inline string",
       isRepeatable: false,
+      priority: 99,
       args: {
         name: "system-prompt-override-inline",
         isOptional: true,
+        description: "Inline system message",
       },
     },
     {
       name: ["-f", "--system-prompt-override-file"],
       description: "Overrides the system message from a specified file",
       isRepeatable: false,
+      priority: 99,
       args: {
         name: "system-prompt-override-file",
         template: "filepaths",
-        isVariadic: true,
+        isVariadic: false,
         isOptional: true,
+        description: "File containing system message",
       },
     },
     {
       name: ["-a", "--additional-context-file"],
       description: "Specifies a file from which additional request context is loaded",
       isRepeatable: false,
+      priority: 500,
       args: {
         name: "additional-context-file",
         template: "filepaths",
         isVariadic: true,
         isOptional: true,
+        description: "File containing additional context",
       },
     },
     {
       name: ["-u", "--upload-image-path"],
       description: "Sets the input file to use",
+      priority: 150,
       isRepeatable: false,
       args: {
         name: "upload-image-path",
         template: "filepaths",
         isVariadic: true,
         isOptional: true,
+        description: "File path for upload",
       },
     },
     {
       name: ["-d", "--download-media"],
       description: "Downloads all media files listed in the output to a specified directory",
       isRepeatable: false,
+      priority: 500,
       args: {
         name: "download-media",
         template: "folders",
         isVariadic: true,
         isOptional: true,
+        description: "Directory to download media files",
       },
     },
     {
       name: "--upsert-no-upload",
       description: "Sends a JSON payload to the specified endpoint without uploading files",
       isRepeatable: false,
+      priority: 200,
       args: {
         name: "upsert-no-upload",
         isOptional: true,
+        description: "JSON payload without upload",
       },
     },
     {
       name: "--upsert-with-upload",
       description: "Uploads a file to the specified endpoint",
       isRepeatable: false,
+      priority: 200,
       args: {
         name: "upsert-with-upload",
         template: "filepaths",
         isVariadic: true,
         isOptional: true,
+        description: "File path for upload",
       },
     },
     {
-      name: ["--generate-autocomplete"],
+      name: "--generate-autocomplete",
+      priority: 7,
       description: "Generates a bash autocomplete script",
-
+      icon: "🔄",
     },
     {
       name: "--generate-fig-autocomplete",
+      priority: 7,
       description: "Generates a fig autocomplete script",
+      icon: "🔄",
     },
     {
       name: ["-p", "--parse-code-output"],
+      priority: 400,
       description: "Extracts and displays only the code blocks from the response",
+      exclusiveOn: ["-z", "--full-output", "-m", "--markdown-output"],
+      icon: "💻",
     },
     {
       name: ["-z", "--full-output"],
+      priority: 5,
       description: "Outputs all response data in JSON format",
+      exclusiveOn: ["-p", "--parse-code-output", "-m", "--markdown-output"],
+      icon: "📄",
     },
     {
       name: ["-m", "--markdown-output"],
+      priority: 400,
       description: "Outputs the response to the terminal in stylized markdown. Do not use for pipelines",
-    },
-    {
-      name: "--webhook",
-      description: "Sends the command payload to the webhook URL specified in config.json",
+      exclusiveOn: ["-z", "--full-output", "-p", "--parse-code-output"],
+      icon: "📑",
     },
     {
       name: ["-h", "--help"],
+      priority: 0,
       description: "Print help",
+      icon: "❓",
     },
     {
       name: ["-V", "--version"],
+      priority: 0,
       description: "Print version",
+      icon: "ℹ️",
+    },
+    {
+      name: ["-o", "--override"],
+      description: "Overrides any entry in the config with the specified key-value pair",
+      isRepeatable: true,
+      priority: 150,
+      args: {
+        name: "override",
+        description: "KEY=VALUE",
+        isOptional: false,
+        generators: {
+          script: (tokens) => {
+            const flowName = tokens[1]; // Assuming the flowname is the first argument after the command
+            if (!flowName) return [];
+            return [
+              "jq",
+              "-r",
+              `map(select(.name == "${flowName}") | .overrideConfig | paths(scalars) as $p | ($p | map(tostring) | join("."))) | .[]`,
+              "/Users/n/RustroverProjects/fluent_cli/fluent_cli/config.json"
+            ];
+          },
+          postProcess: (out: string) => {
+            return out.split('\n').filter(Boolean).map((key) => {
+              return {
+                name: key,
+                description: "Config key",
+                icon: "🔧",
+              };
+            });
+          },
+        },
+      },
+      icon: "🔧",
     },
   ],
 };

--- a/fluent_cli/src/config.rs
+++ b/fluent_cli/src/config.rs
@@ -27,6 +27,9 @@ pub struct FlowConfig {
     pub webhook_url: Option<String>,
     pub webhook_headers: Option<Value>,
     pub engine: String,
+    pub input_type: Option<String>,
+    pub output_type: Option<String>,
+    pub input_value: Option<String>,
 }
 
 

--- a/fluent_cli/src/main.rs
+++ b/fluent_cli/src/main.rs
@@ -48,6 +48,10 @@ use crossterm::style::Stylize;
 use tokio::time::Instant;
 
 // use env_logger; // Uncomment this when you are using it to initialize logs
+
+
+use std::collections::HashMap;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
@@ -56,7 +60,7 @@ async fn main() -> Result<()> {
     let mut configs = config::load_config().unwrap();
     let configs_clone = configs.clone();
 
-    let  mut command = Command::new("fluent")
+    let mut command = Command::new("fluent")
         .arg_required_else_help(true)
         .allow_external_subcommands(true)
         .bin_name("fluent")
@@ -70,114 +74,103 @@ async fn main() -> Result<()> {
             .help("The flow name to invoke")
             .action(ArgAction::Set)
             .requires("request")
-             .required_unless_present_any([
-                "generate-fig-autocomplete",
-            ]))
-
+            .required_unless_present_any(["generate-fig-autocomplete"]))
         .arg(Arg::new("request")
             .index(2)
             .help("The request to send the workflow")
             .action(ArgAction::Set)
             .value_parser(clap::builder::NonEmptyStringValueParser::new())
             .requires("flowname")
-            .required_unless_present_any([
-                "generate-fig-autocomplete",
-            ]))
-
+            .required_unless_present_any(["generate-fig-autocomplete"]))
         .arg(Arg::new("context")
             .help("Optional context provided through <stdin>")
             .action(ArgAction::Set)
             .required(false))
-
         .arg(Arg::new("additional-context-file")
             .long("additional-context-file")
-            .short('a')  // Assigns a short flag
+            .short('a')
             .help("Specifies a file from which additional request context is loaded")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .value_hint(clap::ValueHint::FilePath)
             .required(false))
-
         .arg(Arg::new("upload-image-path")
             .long("upload-image-path")
-            .short('u')  // Assigns a short flag
+            .short('u')
             .value_hint(clap::ValueHint::FilePath)
             .value_name("FilePath")
             .help("Sets the input file to use")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .required(false))
-
         .arg(Arg::new("upsert-no-upload")
             .long("upsert-no-upload")
             .help("Sends a JSON payload to the specified endpoint without uploading files")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .required(false))
-
         .arg(Arg::new("upsert-with-upload")
             .long("upsert-with-upload")
             .value_name("FILE")
             .value_hint(clap::ValueHint::FilePath)
             .help("Uploads a file to the specified endpoint")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .required(false))
-
         .arg(Arg::new("system-prompt-override-inline")
             .long("system-prompt-override-inline")
-            .short('i')  // Assigns a short flag
+            .short('i')
             .help("Overrides the system message with an inline string")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .required(false))
-
         .arg(Arg::new("system-prompt-override-file")
             .long("system-prompt-override-file")
-            .short('f')  // Assigns a short flag
+            .short('f')
             .value_hint(clap::ValueHint::FilePath)
             .help("Overrides the system message from a specified file")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .required(false))
-
         .arg(Arg::new("markdown-output")
             .long("markdown-output")
-            .short('m')  // Assigns a short flag
+            .short('m')
             .conflicts_with_all(["full-output", "parse-code-output"])
             .help("Outputs the response to the terminal in stylized markdown. Do not use for pipelines")
             .action(ArgAction::SetTrue))
-
         .arg(Arg::new("download-media")
             .long("download-media")
-            .short('d')  // Assigns a short flag
+            .short('d')
             .help("Downloads all media files listed in the output to a specified directory")
-            .action(ArgAction::Set)  // Use Append if multiple values may be provided
+            .action(ArgAction::Set)
             .required(false)
             .value_hint(clap::ValueHint::DirPath)
             .value_name("DIRECTORY"))
-
         .arg(Arg::new("parse-code-output")
             .long("parse-code-output")
-            .short('p')  // Assigns a short flag
+            .short('p')
             .help("Extracts and displays only the code blocks from the response")
             .conflicts_with_all(["full-output", "markdown-output"])
             .action(ArgAction::SetTrue))
-
         .arg(Arg::new("full-output")
             .long("full-output")
-            .short('z')  // Assigns a short flag
+            .short('z')
             .help("Outputs all response data in JSON format")
             .conflicts_with_all(["parse-code-output", "markdown-output"])
             .action(ArgAction::SetTrue))
-
         .arg(Arg::new("generate-autocomplete")
             .long("generate-autocomplete")
             .help("Generates a bash autocomplete script")
             .action(ArgAction::SetTrue)
             .exclusive(true))
-
         .arg(Arg::new("generate-fig-autocomplete")
             .long("generate-fig-autocomplete")
             .help("Generates a fig autocomplete script")
             .exclusive(true)
-            .action(ArgAction::SetTrue));
+            .action(ArgAction::SetTrue))
+        .arg(Arg::new("override")
+            .long("override")
+            .short('o')
+            .value_name("KEY=VALUE")
+            .num_args(1..)
+            .help("Overrides any entry in the config with the specified key-value pair")
+            .action(ArgAction::Append)
+            .required(false));
 
- // Assuming build_cli() properly constructs a clap::Command
     if std::env::args().any(|arg| arg == "--generate-fig-autocomplete") {
         generate(Fig, &mut command, "fluent", &mut io::stdout());
         return Ok(());
@@ -204,7 +197,6 @@ async fn main() -> Result<()> {
     let final_context = context.or(if !additional_context.is_empty() { Some(&additional_context) } else { None });
     debug!("Context: {:?}", final_context);
 
-
     // Load override value from CLI if specified for system prompt override, file will always win
     let system_prompt_inline = matches.get_one::<String>("system-prompt-override-inline").map(|s| s.as_str());
     let system_prompt_file = matches.get_one::<String>("system-prompt-override-file").map(|s| s.as_str());
@@ -217,7 +209,6 @@ async fn main() -> Result<()> {
     } else {
         system_prompt_inline.map(|s| s.to_string())
     };
-
 
     // Update the configuration with the override if it exists
     // Update the configuration based on what's present in the overrideConfig
@@ -232,10 +223,8 @@ async fn main() -> Result<()> {
         }
     }
 
-
     let file_path = matches.get_one::<String>("upload-image-path").map(|s| s.as_str());
     let _file_path_clone = matches.get_one::<String>("upload-image-path").map(|s| s.as_str());
-
 
     // Determine the final context from various sources
     let file_context = matches.get_one::<String>("additional-context-file").map(|s| s.as_str());
@@ -246,7 +235,6 @@ async fn main() -> Result<()> {
     }
     let file_contents_clone = file_contents.clone();
 
-
     // Combine file contents with other forms of context if necessary
     let actual_final_context = match (final_context, file_contents.is_empty()) {
         (Some(cli_context), false) => Some(format!("\n{}\n{}\n", cli_context, file_contents)),
@@ -254,38 +242,39 @@ async fn main() -> Result<()> {
         (Some(cli_context), true) => Some(cli_context.to_string()),
         (None, true) => None,
     };
-    let _actual_final_context_clone  = actual_final_context.clone();
-    let actual_final_context_clone2  = actual_final_context.clone();
+    let _actual_final_context_clone = actual_final_context.clone();
+    let actual_final_context_clone2 = actual_final_context.clone();
 
     debug!("Actual Final context: {:?}", actual_final_context);
     let new_question = if let Some(ctx) = actual_final_context {
-        format!("\n{}\n{}\n", request, ctx)  // Concatenate request and context
+        format!("\n{}\n{}\n", request, ctx) // Concatenate request and context
     } else {
-        request.to_string()  // Use request as is if no context
+        request.to_string() // Use request as is if no context
     };
 
     // Decrypt the keys in the flow config
     let mut env_guard = EnvVarGuard::new();
     env_guard.decrypt_amber_keys_for_flow(flow).unwrap();
-    //debug!("EnvGuard result: {:?}", env_guard_result);
 
-    // Within the main function after parsing command-line arguments
+    // Handle upsert with upload
     if let Some(files) = matches.get_one::<String>("upsert-with-upload").map(|s| s.as_str()) {
         let file_paths: Vec<&str> = files.split(',').collect();
         debug!("Uploading files: {:?}", file_paths);
         let flow = configs_clone.iter().find(|f| f.name == flowname).expect("Flow not found");
         debug!("Flow: {:?}", flow);
 
-        // Construct the URL using the upsert path
-        let api_url = format!("{}://{}:{}{}{}", flow.protocol, flow.hostname, flow.port, flow_clone.upsert_path.unwrap_or_default(), flow.chat_id);
+        let api_url = format!(
+            "{}://{}:{}{}{}",
+            flow.protocol, flow.hostname, flow.port, flow_clone.upsert_path.unwrap_or_default(), flow.chat_id
+        );
         debug!("API URL: {}", api_url);
-        // Call the upload function in the client module
         if let Err(e) = client::upload_files(&api_url, file_paths).await {
             eprintln!("Error uploading files: {}", e);
         }
     }
 
-    if let Some(json_str) = matches.get_one::<String>("upsert-no-upload").map(|s| s.as_str())  {
+    // Handle upsert with no upload
+    if let Some(json_str) = matches.get_one::<String>("upsert-no-upload").map(|s| s.as_str()) {
         let inline_json: serde_json::Value = serde_json::from_str(json_str).unwrap_or_else(|err| {
             eprintln!("Error parsing inline JSON: {}", err);
             serde_json::json!({})
@@ -309,7 +298,10 @@ async fn main() -> Result<()> {
         }
         debug!("Merged override config: {:?}", override_config);
 
-        let api_url = format!("{}://{}:{}{}{}", flow.protocol, flow.hostname, flow.port, flow_clone2.upsert_path.unwrap_or_default(), flow.chat_id);
+        let api_url = format!(
+            "{}://{}:{}{}{}",
+            flow.protocol, flow.hostname, flow.port, flow_clone2.upsert_path.unwrap_or_default(), flow.chat_id
+        );
         debug!("API URL: {}", api_url);
 
         // Use the merged override config as the payload
@@ -318,34 +310,52 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Handle inline overrides
+    if let Some(overrides) = matches.get_many::<String>("override") {
+        let mut override_config = flow.override_config.clone();
+        let overrides: HashMap<String, String> = overrides
+            .map(|s| parse_key_value_pair(s).unwrap())
+            .collect();
+
+        for (key, value) in overrides {
+            if let Some(obj) = override_config.as_object_mut() {
+                if obj.contains_key(&key) {
+                    obj.insert(key, serde_json::Value::String(value));
+                }
+            }
+        }
+
+        flow.override_config = override_config;
+    }
+
     let spinner = ProgressBar::new_spinner();
-    spinner.set_style(ProgressStyle::default_spinner()
-        .tick_strings(&[
-            "",
-            "⫸ ",
-            "⫸⫸ ",
-            "⫸⫸⫸ ",
-            "⫸⫸⫸⫸ ",
-            "💛⫸⫸⫸⫸ ",
-            "⫸💛⫸⫸⫸ ",
-            "⫸⫸💛⫸⫸ ",
-            "⫸⫸⫸💛⫸ ",
-            "⫸⫸⫸⫸💛 ",
-            "⫸⫸⫸💛⫷ ",
-            "⫸⫸💛⫷⫷ ",
-            "⫸💛⫷⫷⫷ ",
-            "💛⫷⫷⫷⫷ ",
-            "⫷⫷⫷⫷ ",
-            "⫷⫷⫷ ",
-            "⫷⫷ ",
-            "⫷ ",
-            " ",
-
-        ])
-        .template("{spinner:.yellow}{msg}{spinner:.yellow}")
-        .expect("Failed to set progress style"));
+    spinner.set_style(
+        ProgressStyle::default_spinner()
+            .tick_strings(&[
+                "",
+                "⫸ ",
+                "⫸⫸ ",
+                "⫸⫸⫸ ",
+                "⫸⫸⫸⫸ ",
+                "💛⫸⫸⫸⫸ ",
+                "⫸💛⫸⫸⫸ ",
+                "⫸⫸💛⫸⫸ ",
+                "⫸⫸⫸💛⫸ ",
+                "⫸⫸⫸⫸💛 ",
+                "⫸⫸⫸💛⫷ ",
+                "⫸⫸💛⫷⫷ ",
+                "⫸💛⫷⫷⫷ ",
+                "💛⫷⫷⫷⫷ ",
+                "⫷⫷⫷⫷ ",
+                "⫷⫷⫷ ",
+                "⫷⫷ ",
+                "⫷ ",
+                " ",
+            ])
+            .template("{spinner:.yellow}{msg}{spinner:.yellow}")
+            .expect("Failed to set progress style"),
+    );
     spinner.enable_steady_tick(Duration::from_millis(300));
-
 
     let engine_type = &flow.engine;
     let start_time = Instant::now();
@@ -353,7 +363,7 @@ async fn main() -> Result<()> {
     print_status(&spinner, flowname, request, actual_final_context_clone2.as_ref().unwrap_or(&new_question).as_str());
     spinner.tick();
     debug!("Preparing Payload");
-    let payload = crate::client::prepare_payload(flow, request, file_path, actual_final_context_clone2, &cli_args, &file_contents_clone ).await?;
+    let payload = crate::client::prepare_payload(flow, request, file_path, actual_final_context_clone2, &cli_args, &file_contents_clone).await?;
     let response = crate::client::send_request(flow, &payload).await?;
     debug!("Handling Response");
 
@@ -366,26 +376,39 @@ async fn main() -> Result<()> {
         "Request: ".grey().italic(),
         request.bright_blue().italic(),
         "Duration: ".grey().italic(),
-        format!("{:.4}s", duration.as_secs_f32()).green().italic(),  // Apply bright yellow color to duration
+        format!("{:.4}s", duration.as_secs_f32()).green().italic(), // Apply bright yellow color to duration
         client::print_full_width_bar("-")
     ));
 
-    //spinner.finish_and_clear();
     match engine_type.as_str() {
         "flowise" | "webhook" => {
             // Handle Flowise output
             handle_response(response.as_str(), matches).await
-        },
+        }
         "langflow" => {
             // Handle LangFlow output
             client::handle_langflow_response(response.as_str(), matches).await
-        },
-        _ => {
-                // Handle default output);
-                return Err(Error::from(serde_json::Error::custom("Unsupported engine type")));
         }
-    }.expect("TODO: panic message");
-        eprint!("\n\n{}\n\n", print_full_width_bar("■"));
+        _ => {
+            // Handle default output);
+            return Err(Error::from(serde_json::Error::custom("Unsupported engine type")));
+        }
+    }
+        .expect("TODO: panic message");
+    eprint!("\n\n{}\n\n", print_full_width_bar("■"));
     Ok(())
 }
+
+fn parse_key_value_pair(pair: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = pair.splitn(2, '=').collect();
+    if parts.len() == 2 {
+        Some((parts[0].to_string(), parts[1].to_string()))
+    } else {
+        None
+    }
+}
+
+
+
+
 


### PR DESCRIPTION
    This commit introduces the ability to override specific config entries directly from the command line using the -o or --override flag. This provides
    greater flexibility and control over workflow execution without modifying the config file.
    
    Key changes:
    
    - Adds -o/--override flag to the CLI, allowing users to specify key-value pairs for config overrides.
    - Implements logic to parse and apply these overrides to the flow configuration before execution.
    - Enhances Fig autocomplete script to suggest available config keys for overrides.
    - Improves error handling and debugging messages related to config overrides.
    
    This feature streamlines the workflow customization process, enabling users to quickly experiment with different settings and optimize workflow 
    behavior.

┆Issue is synchronized with this [Trello card](https://trello.com/c/AM93pyjk) by [Unito](https://www.unito.io)
