### PR TITLE
Add agent crate and CLI subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [workspace]
 members = [
     "crates/fluent-cli",
+    "crates/fluent-agent",
     "crates/fluent-core",
     "crates/fluent-engines",
     "crates/fluent-storage",
@@ -19,6 +20,7 @@ fluent-core = { path = "crates/fluent-core" }
 fluent-engines = { path = "crates/fluent-engines" }
 fluent-storage = { path = "crates/fluent-storage" }
 fluent-sdk = { path = "crates/fluent-sdk" }
+fluent-agent = { path = "crates/fluent-agent" }
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
@@ -39,6 +41,7 @@ fluent-core = { path = "crates/fluent-core" }
 fluent-engines = { path = "crates/fluent-engines" }
 fluent-storage = { path = "crates/fluent-storage" }
 fluent-sdk = { path = "crates/fluent-sdk" }
+fluent-agent = { path = "crates/fluent-agent" }
 serde = { version = "^1.0" }
 lambda_runtime = "^0.13"
 serde_json = "^1.0"

--- a/crates/fluent-agent/Cargo.toml
+++ b/crates/fluent-agent/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "fluent-agent"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fluent-engines = { workspace = true }
+fluent-core = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+async-trait = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+reqwest = { workspace = true }
+clap = { workspace = true }
+

--- a/crates/fluent-agent/src/lib.rs
+++ b/crates/fluent-agent/src/lib.rs
@@ -1,0 +1,82 @@
+use anyhow::{anyhow, Result};
+use fluent_core::traits::Engine;
+use fluent_core::types::Request;
+use std::path::Path;
+use std::process::Stdio;
+use tokio::fs;
+use tokio::process::Command;
+
+/// Simple agent that keeps a history of prompt/response pairs.
+pub struct Agent {
+    engine: Box<dyn Engine>,
+    history: Vec<(String, String)>,
+}
+
+impl Agent {
+    /// Create a new agent from an engine.
+    pub fn new(engine: Box<dyn Engine>) -> Self {
+        Self { engine, history: Vec::new() }
+    }
+
+    /// Send a prompt to the engine and store the response in history.
+    pub async fn send(&mut self, prompt: &str) -> Result<String> {
+        let request = Request { flowname: "agent".to_string(), payload: prompt.to_string() };
+        let response = self.engine.execute(&request).await?;
+        let content = response.content.clone();
+        self.history.push((prompt.to_string(), content.clone()));
+        Ok(content)
+    }
+
+    /// Read a file asynchronously.
+    pub async fn read_file(&self, path: &Path) -> Result<String> {
+        Ok(fs::read_to_string(path).await?)
+    }
+
+    /// Write a file asynchronously.
+    pub async fn write_file(&self, path: &Path, content: &str) -> Result<()> {
+        fs::write(path, content).await.map_err(Into::into)
+    }
+
+    /// Run a shell command and capture stdout and stderr.
+    pub async fn run_command(&self, cmd: &str, args: &[&str]) -> Result<String> {
+        let output = Command::new(cmd)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await?;
+        let mut result = String::from_utf8_lossy(&output.stdout).to_string();
+        if !output.status.success() {
+            result.push_str(&String::from_utf8_lossy(&output.stderr));
+        }
+        Ok(result)
+    }
+
+    /// Commit changes in the current git repository.
+    pub async fn git_commit(&self, message: &str) -> Result<()> {
+        self.run_command("git", &["add", "."]).await?;
+        let status = Command::new("git")
+            .args(["commit", "-m", message])
+            .status()
+            .await?;
+        if !status.success() {
+            return Err(anyhow!("git commit failed"));
+        }
+        Ok(())
+    }
+
+    /// Run a simple plan -> generate -> test -> commit cycle using the engine.
+    pub async fn run_cycle(&mut self, prompt: &str) -> Result<()> {
+        let plan = self.send(&format!("Plan: {}", prompt)).await?;
+        let _generation = self.send(&format!("Generate code based on plan:\n{}", plan)).await?;
+
+        let test_output = self.run_command("cargo", &["test", "--quiet"]).await?;
+        if !test_output.contains("0 failed") {
+            return Err(anyhow!("tests failed"));
+        }
+
+        self.git_commit(prompt).await?;
+        Ok(())
+    }
+}
+

--- a/crates/fluent-cli/Cargo.toml
+++ b/crates/fluent-cli/Cargo.toml
@@ -18,6 +18,7 @@ indicatif = { workspace = true }
 owo-colors = { workspace = true }
 regex = { workspace = true }
 serde_yaml = { workspace = true }
+fluent-agent = { path = "../fluent-agent" }
 #fluent-storage = { path = "../fluent-storage" }  # is not used
 #clap_complete = "4.5.1"  #is not used
 #atty = "0.2.14" "use standard std::io::IsTerminal"

--- a/crates/fluent-cli/src/lib.rs
+++ b/crates/fluent-cli/src/lib.rs
@@ -34,7 +34,7 @@ pub mod cli {
 
     use log::{debug, error, info};
     use serde_json::Value;
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncReadExt, AsyncBufReadExt, BufReader};
 
     use crate::{create_llm_engine, generate_and_execute_cypher};
     use fluent_core::neo4j_client::{InteractionStats, Neo4jClient};
@@ -280,6 +280,10 @@ pub mod cli {
                             .action(ArgAction::SetTrue),
                     ),
             )
+            .subcommand(
+                Command::new("agent")
+                    .about("Start interactive agent loop")
+            )
     }
 
     pub async fn get_neo4j_query_llm(config: &Config) -> Option<(Box<dyn Engine>, &EngineConfig)> {
@@ -362,6 +366,25 @@ pub mod cli {
         pb.set_message(format!("Processing {} request...", engine_name));
         pb.enable_steady_tick(Duration::from_millis(spinner_config.interval));
         pb.set_length(100);
+
+        if matches.subcommand_matches("agent").is_some() {
+            let engine: Box<dyn Engine> = create_engine(engine_config).await?;
+            let mut agent = Agent::new(engine);
+            let mut reader = BufReader::new(tokio::io::stdin());
+            let mut line = String::new();
+            println!("Starting agent loop. Type 'exit' to quit.");
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).await? == 0 { break; }
+                let prompt = line.trim();
+                if prompt.eq_ignore_ascii_case("exit") { break; }
+                if prompt.is_empty() { continue; }
+                if let Err(e) = agent.run_cycle(prompt).await {
+                    eprintln!("Agent error: {}", e);
+                }
+            }
+            return Ok(());
+        }
 
         if let Some(cypher_query) = matches.get_one::<String>("generate-cypher") {
             let neo4j_config = engine_config


### PR DESCRIPTION
## Summary
- introduce new `fluent-agent` crate implementing an iterative agent
- expose `fluent agent` subcommand
- wire new crate into workspace and CLI

## Testing
- `cargo check` *(fails: failed to download dependencies)*
- `cargo test` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ff8fa0ab88324ac23f46d84884b57