### PR TITLE
Add interactive pipeline builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,4 @@ mime_guess = { version = "^2.0" }
 futures-util = { version = "^0.3" }
 tempfile = "^3.10"
 futures = "^0.3"
+dialoguer = "^0.11"

--- a/crates/fluent-cli/Cargo.toml
+++ b/crates/fluent-cli/Cargo.toml
@@ -18,6 +18,8 @@ indicatif = { workspace = true }
 owo-colors = { workspace = true }
 regex = { workspace = true }
 serde_yaml = { workspace = true }
+termimad = { workspace = true }
+dialoguer = { workspace = true }
 #fluent-storage = { path = "../fluent-storage" }  # is not used
 #clap_complete = "4.5.1"  #is not used
 #atty = "0.2.14" "use standard std::io::IsTerminal"

--- a/crates/fluent-cli/src/lib.rs
+++ b/crates/fluent-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod pipeline_builder;
 
 use std::pin::Pin;
 
@@ -280,6 +281,10 @@ pub mod cli {
                             .action(ArgAction::SetTrue),
                     ),
             )
+            .subcommand(
+                Command::new("build-pipeline")
+                    .about("Interactively build a pipeline")
+            )
     }
 
     pub async fn get_neo4j_query_llm(config: &Config) -> Option<(Box<dyn Engine>, &EngineConfig)> {
@@ -329,6 +334,11 @@ pub mod cli {
                     }
                 }
 
+                std::process::exit(0);
+            }
+
+            Some(("build-pipeline", _sub_matches)) => {
+                crate::pipeline_builder::build_interactively().await?;
                 std::process::exit(0);
             }
 

--- a/crates/fluent-cli/src/pipeline_builder.rs
+++ b/crates/fluent-cli/src/pipeline_builder.rs
@@ -1,0 +1,90 @@
+use std::io::{stdout, Write};
+use anyhow::Result;
+use termimad::crossterm::{execute, terminal::{Clear, ClearType}};
+use dialoguer::{Select, Input, Confirm};
+use std::path::PathBuf;
+use fluent_engines::pipeline_executor::{Pipeline, PipelineStep, FileStateStore, PipelineExecutor};
+
+pub async fn build_interactively() -> Result<()> {
+    execute!(stdout(), Clear(ClearType::All))?;
+    let name: String = Input::new()
+        .with_prompt("Pipeline name")
+        .interact_text()?;
+
+    let mut pipeline = Pipeline { name, steps: Vec::new() };
+
+    loop {
+        execute!(stdout(), Clear(ClearType::All))?;
+        println!("Building pipeline: {}", pipeline.name);
+        for (idx, step) in pipeline.steps.iter().enumerate() {
+            println!("{}. {:?}", idx + 1, step_name(step));
+        }
+        let action = Select::new()
+            .with_prompt("Choose action")
+            .items(&["Add step", "Finish"])
+            .default(0)
+            .interact()?;
+        if action == 1 { break; }
+
+        let step_type = Select::new()
+            .with_prompt("Step type")
+            .items(&["Command", "ShellCommand", "PrintOutput"])
+            .default(0)
+            .interact()?;
+
+        match step_type {
+            0 => {
+                let name: String = Input::new().with_prompt("Step name").interact_text()?;
+                let command: String = Input::new().with_prompt("Command").interact_text()?;
+                let save: String = Input::new().with_prompt("Save output variable (optional)").allow_empty(true).interact_text()?;
+                pipeline.steps.push(PipelineStep::Command {
+                    name,
+                    command,
+                    save_output: if save.is_empty() { None } else { Some(save) },
+                    retry: None,
+                });
+            }
+            1 => {
+                let name: String = Input::new().with_prompt("Step name").interact_text()?;
+                let command: String = Input::new().with_prompt("Shell command").interact_text()?;
+                let save: String = Input::new().with_prompt("Save output variable (optional)").allow_empty(true).interact_text()?;
+                pipeline.steps.push(PipelineStep::ShellCommand {
+                    name,
+                    command,
+                    save_output: if save.is_empty() { None } else { Some(save) },
+                    retry: None,
+                });
+            }
+            2 => {
+                let name: String = Input::new().with_prompt("Step name").interact_text()?;
+                let value: String = Input::new().with_prompt("Value").interact_text()?;
+                pipeline.steps.push(PipelineStep::PrintOutput { name, value });
+            }
+            _ => {}
+        }
+    }
+
+    let file: String = Input::new().with_prompt("Save pipeline to file").interact_text()?;
+    let yaml = serde_yaml::to_string(&pipeline)?;
+    std::fs::write(&file, yaml)?;
+    println!("Pipeline saved to {}", file);
+
+    if Confirm::new().with_prompt("Run pipeline now?").interact()? {
+        let input: String = Input::new().with_prompt("Pipeline input").interact_text()?;
+        let state_store_dir = PathBuf::from("./pipeline_states");
+        tokio::fs::create_dir_all(&state_store_dir).await?;
+        let state_store = FileStateStore { directory: state_store_dir };
+        let executor = PipelineExecutor::new(state_store, false);
+        executor.execute(&pipeline, &input, false, None).await?;
+    }
+    Ok(())
+}
+
+fn step_name(step: &PipelineStep) -> &str {
+    match step {
+        PipelineStep::Command { name, .. } => name,
+        PipelineStep::ShellCommand { name, .. } => name,
+        PipelineStep::PrintOutput { name, .. } => name,
+        _ => "step",
+    }
+}


### PR DESCRIPTION
## Summary
- add `dialoguer` to workspace dependencies
- add Termimad/crossterm based pipeline builder
- expose new `build-pipeline` subcommand in CLI
- wire interactive builder in CLI command dispatch

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test -p fluent-cli --no-run` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685ff8ff55408324a26505e456089044