### PR TITLE
Add cache with CLI toggle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,5 @@ mime_guess = { version = "^2.0" }
 futures-util = { version = "^0.3" }
 tempfile = "^3.10"
 futures = "^0.3"
+sled = "^0.34"
+sha2 = "^0.10"

--- a/crates/fluent-cli/src/lib.rs
+++ b/crates/fluent-cli/src/lib.rs
@@ -231,6 +231,12 @@ pub mod cli {
                     .action(ArgAction::SetTrue),
             )
             .arg(
+                Arg::new("cache")
+                    .long("cache")
+                    .help("Enable request caching")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
                 Arg::new("markdown")
                     .short('m')
                     .long("markdown")
@@ -292,6 +298,12 @@ pub mod cli {
 
     pub async fn run() -> Result<()> {
         let matches = build_cli().get_matches();
+
+        if matches.get_flag("cache") {
+            std::env::set_var("FLUENT_CACHE", "1");
+        } else {
+            std::env::set_var("FLUENT_CACHE", "0");
+        }
 
         let _: Result<(), Error> = match matches.subcommand() {
             Some(("pipeline", sub_matches)) => {

--- a/crates/fluent-core/Cargo.toml
+++ b/crates/fluent-core/Cargo.toml
@@ -28,6 +28,8 @@ termimad = { workspace = true }
 syntect = { workspace = true }
 owo-colors = { workspace = true }
 pdf-extract = { workspace = true }
+sled = { workspace = true }
+sha2 = { workspace = true }
 
 
 #rust-bert = {  version = "0.18.0"  }  #Is not used

--- a/crates/fluent-core/src/cache.rs
+++ b/crates/fluent-core/src/cache.rs
@@ -1,0 +1,41 @@
+use crate::types::Response;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sled::Db;
+use std::path::Path;
+
+#[derive(Serialize, Deserialize)]
+struct StoredResponse(Response);
+
+pub struct RequestCache {
+    db: Db,
+}
+
+impl RequestCache {
+    pub fn new(path: &Path) -> Result<Self> {
+        let db = sled::open(path)?;
+        Ok(Self { db })
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<Response>> {
+        if let Some(v) = self.db.get(key)? {
+            let resp: StoredResponse = serde_json::from_slice(&v)?;
+            Ok(Some(resp.0))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn insert(&self, key: &str, response: &Response) -> Result<()> {
+        let data = serde_json::to_vec(&StoredResponse(response.clone()))?;
+        self.db.insert(key, data)?;
+        Ok(())
+    }
+}
+
+pub fn cache_key(payload: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(payload.as_bytes());
+    format!("{:x}", hasher.finalize())
+}

--- a/crates/fluent-core/src/lib.rs
+++ b/crates/fluent-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod neo4j_client;
 mod voyageai_client;
 pub mod output_processor;
 pub mod spinner_configuration;
+pub mod cache;
 
 
 

--- a/crates/fluent-engines/src/openai.rs
+++ b/crates/fluent-engines/src/openai.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use base64::engine::general_purpose::STANDARD as Base64;
 use base64::Engine as Base64Engine;
+use fluent_core::cache::{cache_key, RequestCache};
 use fluent_core::config::EngineConfig;
 use fluent_core::neo4j_client::Neo4jClient;
 use fluent_core::traits::{Engine, EngineConfigProcessor, OpenAIConfigProcessor};
@@ -22,6 +23,7 @@ pub struct OpenAIEngine {
     config: EngineConfig,
     config_processor: OpenAIConfigProcessor,
     neo4j_client: Option<Arc<Neo4jClient>>,
+    cache: Option<RequestCache>,
 }
 
 impl OpenAIEngine {
@@ -32,10 +34,18 @@ impl OpenAIEngine {
             None
         };
 
+        let cache = if std::env::var("FLUENT_CACHE").ok().as_deref() == Some("1") {
+            let path = std::env::var("FLUENT_CACHE_DIR").unwrap_or_else(|_| "fluent_cache".to_string());
+            Some(RequestCache::new(std::path::Path::new(&path))?)
+        } else {
+            None
+        };
+
         Ok(Self {
             config,
             config_processor: OpenAIConfigProcessor,
             neo4j_client,
+            cache,
         })
     }
 }
@@ -88,6 +98,12 @@ impl Engine for OpenAIEngine {
         request: &'a Request,
     ) -> Box<dyn Future<Output = Result<Response>> + Send + 'a> {
         Box::new(async move {
+            if let Some(cache) = &self.cache {
+                if let Some(cached) = cache.get(&cache_key(&request.payload))? {
+                    return Ok(cached);
+                }
+            }
+
             let client = Client::new();
             debug!("Config: {:?}", self.config);
 
@@ -155,12 +171,18 @@ impl Engine for OpenAIEngine {
                 .as_str()
                 .map(String::from);
 
-            Ok(Response {
+            let response = Response {
                 content,
                 usage,
                 model,
                 finish_reason,
-            })
+            };
+
+            if let Some(cache) = &self.cache {
+                let _ = cache.insert(&cache_key(&request.payload), &response);
+            }
+
+            Ok(response)
         })
     }
 
@@ -216,6 +238,12 @@ impl Engine for OpenAIEngine {
         file_path: &'a Path,
     ) -> Box<dyn Future<Output = Result<Response>> + Send + 'a> {
         Box::new(async move {
+            let key_input = format!("{}:{}", request.payload, file_path.display());
+            if let Some(cache) = &self.cache {
+                if let Some(cached) = cache.get(&cache_key(&key_input))? {
+                    return Ok(cached);
+                }
+            }
             // Read and encode the file
             let mut file = File::open(file_path).await.context("Failed to open file")?;
             let mut buffer = Vec::new();
@@ -302,12 +330,16 @@ impl Engine for OpenAIEngine {
                 .as_str()
                 .map(String::from);
 
-            Ok(Response {
+            let response = Response {
                 content,
                 usage,
                 model,
                 finish_reason,
-            })
+            };
+            if let Some(cache) = &self.cache {
+                let _ = cache.insert(&cache_key(&key_input), &response);
+            }
+            Ok(response)
         })
     }
 }


### PR DESCRIPTION
## Summary
- add sled-based cache module in `fluent-core`
- enable request caching in `OpenAIEngine`
- expose `--cache` flag in CLI to toggle caching
- wire cache setting via environment variable
- include sled and sha2 in workspace dependencies

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_685ff904d78c83248f97cc304bdcdf68