### PR TITLE
Add pipeline schema validation and unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,5 @@ mime_guess = { version = "^2.0" }
 futures-util = { version = "^0.3" }
 tempfile = "^3.10"
 futures = "^0.3"
+schemars = { version = "^0.8", features = ["derive"] }
+jsonschema = "^0.17"

--- a/crates/fluent-cli/src/lib.rs
+++ b/crates/fluent-cli/src/lib.rs
@@ -52,7 +52,7 @@ pub mod cli {
     use fluent_engines::replicate::ReplicateEngine;
 
     use fluent_engines::pipeline_executor::{
-        FileStateStore, Pipeline, PipelineExecutor, StateStore,
+        validate_pipeline_yaml, FileStateStore, Pipeline, PipelineExecutor, StateStore,
     };
     use fluent_engines::stabilityai::StabilityAIEngine;
     use fluent_engines::webhook::WebhookEngine;
@@ -301,8 +301,9 @@ pub mod cli {
                 let run_id = sub_matches.get_one::<String>("run_id").cloned();
                 let json_output = sub_matches.get_flag("json_output");
 
-                let pipeline: Pipeline =
-                    serde_yaml::from_str(&std::fs::read_to_string(pipeline_file)?)?;
+                let yaml_str = std::fs::read_to_string(pipeline_file)?;
+                validate_pipeline_yaml(&yaml_str)?;
+                let pipeline: Pipeline = serde_yaml::from_str(&yaml_str)?;
                 let state_store_dir = PathBuf::from("./pipeline_states");
                 tokio::fs::create_dir_all(&state_store_dir).await?;
                 let state_store = FileStateStore {

--- a/crates/fluent-engines/Cargo.toml
+++ b/crates/fluent-engines/Cargo.toml
@@ -21,3 +21,6 @@ futures-util = { workspace = true }
 tempfile = { workspace = true }
 futures = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
+schemars = { workspace = true, features = ["derive"] }
+jsonschema = { workspace = true }
+serde_yaml = { workspace = true }

--- a/crates/fluent-engines/src/pipeline_executor.rs
+++ b/crates/fluent-engines/src/pipeline_executor.rs
@@ -20,14 +20,18 @@ use tokio::process::Command;
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use uuid::Uuid;
+use schemars::JsonSchema;
+use jsonschema::{Draft, JSONSchema};
+use serde_yaml;
+use serde_json;
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct Pipeline {
     pub name: String,
     pub steps: Vec<PipelineStep>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 pub enum PipelineStep {
     Command {
         name: String,
@@ -99,18 +103,35 @@ pub enum PipelineStep {
     },
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct RetryConfig {
     max_attempts: u32,
     delay_ms: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct PipelineState {
     pub current_step: usize,
     pub data: HashMap<String, String>,
     pub run_id: String,
     pub start_time: u64,
+}
+
+pub fn pipeline_schema() -> schemars::schema::RootSchema {
+    schemars::schema_for!(Pipeline)
+}
+
+pub fn validate_pipeline_yaml(yaml: &str) -> Result<(), Error> {
+    let value: serde_yaml::Value = serde_yaml::from_str(yaml)?;
+    let schema = pipeline_schema();
+    let compiled = JSONSchema::options()
+        .with_draft(Draft::Draft7)
+        .compile(&serde_json::to_value(&schema)?)?;
+    let instance = serde_json::to_value(&value)?;
+    compiled
+        .validate(&instance)
+        .map(|_| ())
+        .map_err(|errors| anyhow!(errors.map(|e| e.to_string()).collect::<Vec<_>>().join("; ")))
 }
 
 #[async_trait]
@@ -959,5 +980,116 @@ impl StateStore for FileStateStore {
         } else {
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn test_executor() -> PipelineExecutor<FileStateStore> {
+        let dir = tempdir().unwrap();
+        let store = FileStateStore { directory: dir.path().to_path_buf() };
+        PipelineExecutor::new(store, false)
+    }
+
+    #[tokio::test]
+    async fn test_condition() {
+        let executor = test_executor();
+        let pipeline = Pipeline {
+            name: "cond".into(),
+            steps: vec![PipelineStep::Condition {
+                name: "check".into(),
+                condition: "true".into(),
+                if_true: "echo yes".into(),
+                if_false: "echo no".into(),
+            }],
+        };
+
+        let out = executor.execute(&pipeline, "", true, None).await.unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["data"]["output"], "yes");
+    }
+
+    #[tokio::test]
+    async fn test_repeat_until_loop() {
+        let executor = test_executor();
+        let pipeline = Pipeline {
+            name: "loop".into(),
+            steps: vec![
+                PipelineStep::ShellCommand {
+                    name: "init".into(),
+                    command: "echo 0".into(),
+                    save_output: Some("counter".into()),
+                    retry: None,
+                },
+                PipelineStep::RepeatUntil {
+                    name: "inc".into(),
+                    steps: vec![PipelineStep::ShellCommand {
+                        name: "add".into(),
+                        command: "echo $(($counter + 1))".into(),
+                        save_output: Some("counter".into()),
+                        retry: None,
+                    }],
+                    condition: "[ $counter -ge 3 ]".into(),
+                },
+            ],
+        };
+
+        let out = executor.execute(&pipeline, "", true, None).await.unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["data"]["counter"], "3");
+    }
+
+    #[tokio::test]
+    async fn test_parallel() {
+        let executor = test_executor();
+        let pipeline = Pipeline {
+            name: "par".into(),
+            steps: vec![PipelineStep::Parallel {
+                name: "p".into(),
+                steps: vec![
+                    PipelineStep::ShellCommand {
+                        name: "one".into(),
+                        command: "echo a".into(),
+                        save_output: Some("a".into()),
+                        retry: None,
+                    },
+                    PipelineStep::ShellCommand {
+                        name: "two".into(),
+                        command: "echo b".into(),
+                        save_output: Some("b".into()),
+                        retry: None,
+                    },
+                ],
+            }],
+        };
+
+        let out = executor.execute(&pipeline, "", true, None).await.unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["data"]["a"], "a");
+        assert_eq!(v["data"]["b"], "b");
+    }
+
+    #[tokio::test]
+    async fn test_timeout() {
+        let executor = test_executor();
+        let pipeline = Pipeline {
+            name: "timeout".into(),
+            steps: vec![PipelineStep::Timeout {
+                name: "t".into(),
+                duration: 1,
+                step: Box::new(PipelineStep::ShellCommand {
+                    name: "sleep".into(),
+                    command: "sleep 2".into(),
+                    save_output: Some("out".into()),
+                    retry: None,
+                }),
+            }],
+        };
+
+        let res = executor.execute(&pipeline, "", true, None).await;
+        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- validate pipeline YAML with JSON schema
- integrate validator into CLI
- derive JSON schema for pipeline types
- add tests for conditional, loop, parallel and timeout steps

## Testing
- `cargo test --workspace --verbose` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685ff90748748324a5cf152cb709b558