### PR TITLE
Improve Fluent SDK builder ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Fluent CLI is a powerful command-line interface for interacting with various AI engines. It provides a unified way to send requests, receive responses, and manage interactions with different AI services.
 
+For programmatic access, check out the [`fluent-sdk` crate](https://crates.io/crates/fluent-sdk).
+
 ### Installation
 
 Fluent CLI requires Rust and Cargo to be installed on your system. You can install them using the instructions on the [Rust website](https://www.rust-lang.org/tools/install).

--- a/crates/fluent-sdk/Cargo.toml
+++ b/crates/fluent-sdk/Cargo.toml
@@ -2,6 +2,11 @@
 name = "fluent-sdk"
 version = "0.1.0"
 edition = "2021"
+description = "SDK for interacting with the Fluent AI engine configurations"
+license = "MIT"
+repository = "https://github.com/njfio/fluent_cli"
+readme = "../../README.md"
+homepage = "https://fluentcli.com"
 
 
 [dependencies]

--- a/crates/fluent-sdk/examples/openai.rs
+++ b/crates/fluent-sdk/examples/openai.rs
@@ -1,0 +1,13 @@
+use fluent_sdk::prelude::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let request = FluentOpenAIChatRequest::builder()
+        .prompt("Hello, world!".to_string())
+        .openai_key("YOUR_OPENAI_KEY".to_string())
+        .build()?;
+
+    let response = request.run().await?;
+    println!("{:?}", response.data);
+    Ok(())
+}

--- a/crates/fluent-sdk/src/openai.rs
+++ b/crates/fluent-sdk/src/openai.rs
@@ -6,6 +6,7 @@ use crate::{EngineTemplate, FluentRequest, FluentSdkRequest, KeyValue};
 
 impl FluentSdkRequest for FluentOpenAIChatRequest {}
 
+/// Request data used for OpenAI chat completions.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct FluentOpenAIChatRequest {
     pub prompt: String,
@@ -19,6 +20,12 @@ pub struct FluentOpenAIChatRequest {
     pub stop: Option<Vec<String>>,
     pub frequency_penalty: Option<f64>,
     pub presence_penalty: Option<f64>,
+}
+impl FluentOpenAIChatRequest {
+    /// Creates a new [`FluentOpenAIChatRequestBuilder`].
+    pub fn builder() -> FluentOpenAIChatRequestBuilder {
+        FluentOpenAIChatRequestBuilder::default()
+    }
 }
 impl From<FluentOpenAIChatRequest> for FluentRequest {
     fn from(request: FluentOpenAIChatRequest) -> Self {
@@ -60,6 +67,7 @@ impl From<FluentOpenAIChatRequest> for FluentRequest {
     }
 }
 
+/// Builder for [`FluentOpenAIChatRequest`].
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct FluentOpenAIChatRequestBuilder {
     request: FluentOpenAIChatRequest,
@@ -71,12 +79,12 @@ impl Default for FluentOpenAIChatRequestBuilder {
                 prompt: String::new(),
                 openai_key: String::new(),
                 response_format: None,
-                temperature: None,
+                temperature: Some(0.7),
                 max_tokens: None,
-                top_p: None,
+                top_p: Some(1.0),
                 frequency_penalty: None,
                 presence_penalty: None,
-                model: None,
+                model: Some("gpt-3.5-turbo".to_string()),
                 n: None,
                 stop: None,
             },
@@ -85,50 +93,62 @@ impl Default for FluentOpenAIChatRequestBuilder {
 }
 
 impl FluentOpenAIChatRequestBuilder {
+    /// Sets the user prompt.
     pub fn prompt(mut self, prompt: String) -> Self {
         self.request.prompt = prompt;
         self
     }
+    /// Sets the OpenAI API key.
     pub fn openai_key(mut self, openai_key: String) -> Self {
         self.request.openai_key = openai_key;
         self
     }
+    /// Overrides the `response_format` parameter.
     pub fn response_format(mut self, response_format: Value) -> Self {
         self.request.response_format = Some(response_format);
         self
     }
+    /// Overrides the `temperature` parameter.
     pub fn temperature(mut self, temperature: f64) -> Self {
         self.request.temperature = Some(temperature);
         self
     }
+    /// Overrides the `max_tokens` parameter.
     pub fn max_tokens(mut self, max_tokens: i64) -> Self {
         self.request.max_tokens = Some(max_tokens);
         self
     }
+    /// Overrides the `top_p` parameter.
     pub fn top_p(mut self, top_p: f64) -> Self {
         self.request.top_p = Some(top_p);
         self
     }
+    /// Overrides the `frequency_penalty` parameter.
     pub fn frequency_penalty(mut self, frequency_penalty: f64) -> Self {
         self.request.frequency_penalty = Some(frequency_penalty);
         self
     }
+    /// Overrides the `presence_penalty` parameter.
     pub fn presence_penalty(mut self, presence_penalty: f64) -> Self {
         self.request.presence_penalty = Some(presence_penalty);
         self
     }
+    /// Overrides the model to use.
     pub fn model(mut self, model: String) -> Self {
         self.request.model = Some(model);
         self
     }
+    /// Overrides the `n` parameter.
     pub fn n(mut self, n: i8) -> Self {
         self.request.n = Some(n);
         self
     }
+    /// Overrides the `stop` parameter.
     pub fn stop(mut self, stop: Vec<String>) -> Self {
         self.request.stop = Some(stop);
         self
     }
+    /// Builds the request returning an error if required fields are missing.
     pub fn build(self) -> anyhow::Result<FluentOpenAIChatRequest> {
         if self.request.prompt.is_empty() {
             return Err(anyhow!("Prompt is required"));


### PR DESCRIPTION
## Summary
- add new `FluentRequestBuilder` and expose `builder` constructors
- enrich `FluentOpenAIChatRequestBuilder` with defaults and docs
- document SDK availability in README and add crate metadata
- provide example program in `fluent-sdk/examples`

## Testing
- `cargo check --workspace` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_685ff910af448324a9f54ce68a077e67